### PR TITLE
Use SECRET_KEY env var by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ cd nanobox-django
 # Add a convenient way to access your app from the browser
 nanobox dns add local django.dev
 
+# Set the secret key environment variable
+nanobox evar add local SECRET_KEY=mysecretkey
+
 # Run django as you would normally, with Nanobox
 nanobox run python manage.py runserver 0.0.0.0:8000
 ```

--- a/app/settings.py
+++ b/app/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ')oe$1-acfgn)^!evv*y7#kjt9gv+dcnd#wnuw3bdmw511x+*$f'
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Encourage good practice by using `SECRET_KEY` env var by default.

This is pretty subjective and may detract from the the goal of this repo in providing a quick set up for first time users.